### PR TITLE
047 parse input in loop

### DIFF
--- a/src/chatbot/bot_utils.clj
+++ b/src/chatbot/bot_utils.clj
@@ -1,6 +1,5 @@
 (ns chatbot.bot_utils
-  (:require [chatbot.parse :refer [parse-input]]
-            [chatbot.levenshtein :refer [similarity]]))
+  (:require [chatbot.levenshtein :refer [similarity]]))
 
 (def bot-prompt "Chatbot> ")
 
@@ -47,7 +46,7 @@
     If true, function prints random greeting message.
     Otherwise returns false."
     [greeting-vector input]
-    (let [words (parse-input input)]
+    (let [words input]
       (if (seq greeting-vector)
         (let [max-similarity
               (apply max

--- a/src/chatbot/core.clj
+++ b/src/chatbot/core.clj
@@ -3,8 +3,7 @@
             [chatbot.find_park_data :refer [find-park-data]]
             [chatbot.parse :refer [parse-input]]
             [chatbot.bot_utils :as bot]
-            [chatbot.user_utils :as chat-user]
-            [clojure.string :as str]))
+            [chatbot.user_utils :as chat-user]))
 
 
 (defn main-loop

--- a/src/chatbot/core.clj
+++ b/src/chatbot/core.clj
@@ -41,4 +41,4 @@
            (not (= false (keyword-response-main user-input)))
            (bot/bot-print! (find-park-data (keyword-response-main user-input))))
 
-         (recur (chat-user/get-user-input))))))
+         (recur (parse-input (chat-user/get-user-input)))))))

--- a/src/chatbot/core.clj
+++ b/src/chatbot/core.clj
@@ -1,6 +1,7 @@
 (ns chatbot.core
   (:require [chatbot.identify_keyword :refer [keyword-response-main]]
             [chatbot.find_park_data :refer [find-park-data]]
+            [chatbot.parse :refer [parse-input]]
             [chatbot.bot_utils :as bot]
             [chatbot.user_utils :as chat-user]
             [clojure.string :as str]))
@@ -20,8 +21,8 @@
   (chat-user/set-user-prompt!)
   (bot/bot-print! "You can change your username anytime by typing 'username'")
   (bot/bot-print! "Feel free to ask any question about Bertramka!")
-  (loop [user-input (str/lower-case (chat-user/get-user-input))]
-     (if (= "finish" user-input)
+  (loop [user-input (parse-input (chat-user/get-user-input))]
+     (if (and (= 1 (count user-input)) (some #(= "finish" %) user-input))
        (bot/bot-print! (rand-nth bot/possible-goodbye-messages))
        (do
          (cond

--- a/src/chatbot/identify_keyword.clj
+++ b/src/chatbot/identify_keyword.clj
@@ -1,5 +1,5 @@
 (ns chatbot.identify_keyword
-  (:require [chatbot.parse :refer [parse-json parse-input]]
+  (:require [chatbot.parse :refer [parse-json]]
             [chatbot.levenshtein :refer [similarity]]))
 
 (def synonyms-map (parse-json "data/synonyms.json"))
@@ -9,7 +9,7 @@
    and prints the corresponding response.
    If the keyword is not identified, function returns false"
   [synonyms-vector input]
-  (let [words (parse-input input)
+  (let [words input
         synonyms synonyms-vector]
   (loop [synonyms-vec synonyms-vector]
     (let [synonym (first synonyms-vec)]

--- a/test/chatbot/core_test.clj
+++ b/test/chatbot/core_test.clj
@@ -71,7 +71,7 @@
       (= "dogs"
          (keyword-response-main "dog")))))
 
-(deftest keyord-response-main-invalid-test
+(deftest keyword-response-main-invalid-test
   (testing "Testing the keyword identifier function with invalid input"
     (is
       (= false

--- a/test/chatbot/core_test.clj
+++ b/test/chatbot/core_test.clj
@@ -50,32 +50,32 @@
   (testing "Testing keyword identifier with list of vectors and invalid input"
     (is
       (= false
-         (keyword-response-list (vals synonyms-map) "something")))))
+         (keyword-response-list (vals synonyms-map) (parse-input "something"))))))
 
 
 (deftest keyword-response-list-valid-test
   (testing "Testing keyword identifier with list of vectors and invalid input"
     (is
       (= "transportation"
-         (keyword-response-list (vals synonyms-map) "metro")))))
+         (keyword-response-list (vals synonyms-map) (parse-input "metro"))))))
 
 (deftest keyword-response-main-valid-test
   (testing "Testing the keyword identifier function with valid input"
     (is
       (= "biking"
-         (keyword-response-main "bicycle")))))
+         (keyword-response-main (parse-input "bicycle"))))))
 
 (deftest keyword-response-main-test
   (testing "Testing the keyword identifier function with input - dog"
     (is
       (= "dogs"
-         (keyword-response-main "dog")))))
+         (keyword-response-main (parse-input "dog"))))))
 
 (deftest keyword-response-main-invalid-test
   (testing "Testing the keyword identifier function with invalid input"
     (is
       (= false
-         (keyword-response-main "Something")))))
+         (keyword-response-main (parse-input "Something"))))))
 
 (deftest greeting-input-not-identified-test
   (testing "Testing greeting function with the input which is not a greeting"

--- a/test/chatbot/core_test.clj
+++ b/test/chatbot/core_test.clj
@@ -37,14 +37,14 @@
     (is
       (= "wc"
          (keyword-response-vector
-           (vector "wc" "restroom" "bath") "restroom")))))
+           (vector "wc" "restroom" "bath") ("restroom"))))))
 
 (deftest keyword-response-vector-invalid-test
   (testing "Testing keyword identifier function with invalid input"
     (is
       (= false
          (keyword-response-vector
-           (first (vals synonyms-map)) "something")))))
+           (first (vals synonyms-map)) ("something"))))))
 
 (deftest keyword-response-list-invalid-test
   (testing "Testing keyword identifier with list of vectors and invalid input"
@@ -80,11 +80,11 @@
 (deftest greeting-input-not-identified-test
   (testing "Testing greeting function with the input which is not a greeting"
     (is
-      (= false (greeting possible-greetings "something")))))
+      (= false (greeting possible-greetings ("something"))))))
 
 (deftest greeting-input-identified-test
   (testing "Testing greeting function with the input which is a greeting"
-    (let [greeting-result (greeting possible-greetings "hi")]
+    (let [greeting-result (greeting possible-greetings ("hi"))]
       (is
         (= true
            (some #(= greeting-result %) responses))))))

--- a/test/chatbot/core_test.clj
+++ b/test/chatbot/core_test.clj
@@ -37,14 +37,14 @@
     (is
       (= "wc"
          (keyword-response-vector
-           (vector "wc" "restroom" "bath") ("restroom"))))))
+           (vector "wc" "restroom" "bath") (parse-input "restroom"))))))
 
 (deftest keyword-response-vector-invalid-test
   (testing "Testing keyword identifier function with invalid input"
     (is
       (= false
          (keyword-response-vector
-           (first (vals synonyms-map)) ("something"))))))
+           (first (vals synonyms-map)) (parse-input "something"))))))
 
 (deftest keyword-response-list-invalid-test
   (testing "Testing keyword identifier with list of vectors and invalid input"
@@ -80,11 +80,11 @@
 (deftest greeting-input-not-identified-test
   (testing "Testing greeting function with the input which is not a greeting"
     (is
-      (= false (greeting possible-greetings ("something"))))))
+      (= false (greeting possible-greetings (parse-input "something"))))))
 
 (deftest greeting-input-identified-test
   (testing "Testing greeting function with the input which is a greeting"
-    (let [greeting-result (greeting possible-greetings ("hi"))]
+    (let [greeting-result (greeting possible-greetings (parse-input "hi"))]
       (is
         (= true
            (some #(= greeting-result %) responses))))))

--- a/test/chatbot/core_test.clj
+++ b/test/chatbot/core_test.clj
@@ -50,7 +50,8 @@
   (testing "Testing keyword identifier with list of vectors and invalid input"
     (is
       (= false
-         (keyword-response-list (vals synonyms-map) (parse-input "something"))))))
+         (keyword-response-list (vals synonyms-map)
+                                (parse-input "something"))))))
 
 
 (deftest keyword-response-list-valid-test


### PR DESCRIPTION
The parse-input function call has been removed from the functions accepting the user input within the main loop. 
Instead, the user input is parsed in the main loop and is then passed to the functions inside it.

The check of the the terminating word "finish" has been modified, so now the chat is terminated in case the parsed user input contains only one word and that word is equal to "finish" string.

closes #47 